### PR TITLE
feat(cli): add help flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ make
 ```sh
 rkcfgtool <cfg> [actions...] [-o output.cfg]
 rkcfgtool --create <output.cfg> [actions...]
-rkcfgtool --version
+rkcfgtool --help | --version
 ```
 
 Actions:
@@ -23,6 +23,7 @@ Actions:
 - `--add <name> <path>` – append a new entry
 - `--del <idx>` – delete entry
 - `--version` – show rkcfgtool version
+- `--help` – show usage information
 
 ## Tests
 

--- a/rkcfgtool.cpp
+++ b/rkcfgtool.cpp
@@ -177,16 +177,19 @@ static bool rebuildAndWrite(const std::string &outFile,
 static void showHelp() {
   std::cout <<
       R"(Usage:
-  cfgtool <cfg> [actions…] [-o <output.cfg>]
-  cfgtool --create <output.cfg> [actions…]
+  rkcfgtool <cfg> [actions…] [-o <output.cfg>]
+  rkcfgtool --create <output.cfg> [actions…]
+  rkcfgtool --help | --version
 
 Actions (may repeat; executed in order):
   --list                         List entries (default)
   --set-path <idx> <newPath>     Change path of entry <idx>
   --add      <name> <path>       Append a new entry
   --del      <idx>               Delete entry <idx>
-  --create <file>                Start a new CFG instead of reading one
-  --version                      Show rkcfgtool version
+  --create   <file>              Start a new CFG instead of reading one
+  -o, --output <file>            Write result to <file>
+  -V, --version                  Show rkcfgtool version
+  -h, --help                     Show this help message
 )";
 }
 
@@ -194,13 +197,20 @@ Actions (may repeat; executed in order):
  * 6. Main entry
  *-------------------------------------------------------------------*/
 int main(int argc, char *argv[]) {
-  if (argc < 2) {
-    showHelp();
-    return 0;
+  for (int j = 1; j < argc; ++j) {
+    std::string arg = argv[j];
+    if (arg == "--help" || arg == "-h") {
+      showHelp();
+      return 0;
+    }
+    if (arg == "--version" || arg == "-V") {
+      std::cout << "rkcfgtool " << RKCFGTOOL_VERSION << '\n';
+      return 0;
+    }
   }
 
-  if (std::string(argv[1]) == "--version" || std::string(argv[1]) == "-V") {
-    std::cout << "rkcfgtool " << RKCFGTOOL_VERSION << '\n';
+  if (argc < 2) {
+    showHelp();
     return 0;
   }
 

--- a/test.sh
+++ b/test.sh
@@ -5,7 +5,8 @@ set -e
 make clean >/dev/null
 make >/dev/null
 
-# version output
+# help and version output
+./rkcfgtool --help > /dev/null
 ./rkcfgtool --version > /dev/null
 
 # list all sample cfgs


### PR DESCRIPTION
## Summary
- support `--help`/`-h` to show usage
- accept `--version` anywhere on the command line
- document the new options
- test `--help`

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_686fcce567488320ab392c4bac6ff106