### PR TITLE
feat(cli): allow inline create and default output

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,20 @@ make
 ## Usage
 
 ```sh
-rkcfgtool <cfg> [actions...] [-o output.cfg]
-rkcfgtool --create <output.cfg> [actions...]
+rkcfgtool <cfg> [--create] [actions...] [-o output.cfg]
 rkcfgtool --help | --version
 ```
+
+If `-o` is omitted, changes are written back to `<cfg>`.
 
 Actions:
 - `--list` – list entries (default)
 - `--set-path <idx> <newPath>` – change path of entry
+- `--set-name <idx> <newName>` – change name of entry
 - `--add <name> <path>` – append a new entry
 - `--del <idx>` – delete entry
 - `--json` – output entries as JSON
+- `--create` – start a new config instead of reading one
 - `--version` – show rkcfgtool version
 - `--help` – show usage information
 

--- a/test.sh
+++ b/test.sh
@@ -1,34 +1,43 @@
 #!/bin/sh
 set -e
 
-# build
+echo "Building..."
 make >/dev/null
 
-# help and version output
+echo "Checking help and version..."
 ./rkcfgtool --help | grep -q Usage
 ./rkcfgtool --version | grep -q rkcfgtool
 
-# list all sample cfgs
+echo "Validating sample cfgs..."
 for f in cfg/*.cfg; do
     ./rkcfgtool "$f" --json | python3 -m json.tool > /dev/null
 done
 
-# modify existing cfg
+echo "Parsing non-JSON output..."
+./rkcfgtool cfg/config1.cfg > list.txt
+grep -q "=== Entry list" list.txt
+test $(grep -c '^ [0-9]' list.txt) -eq 10
+grep '^ 0 ' list.txt | grep -q loader
+rm list.txt
+
+echo "Modifying existing cfg..."
 cp cfg/config1.cfg t1.cfg
-./rkcfgtool t1.cfg --set-path 0 new.bin --add xxx yyy.img --del 1 -o t2.cfg >/dev/null
-./rkcfgtool t2.cfg --json > out.json
+./rkcfgtool t1.cfg --set-path 0 new.bin --set-name 0 bootloader \
+  --add xxx yyy.img --del 1 >/dev/null
+./rkcfgtool t1.cfg --json > out.json
 python3 - out.json <<'EOF'
 import json,sys
 data=json.load(open(sys.argv[1]))
 assert len(data) == 10
+assert data[0]['name'] == 'bootloader'
 assert data[0]['path'] == 'new.bin'
 assert data[-1]['name'] == 'xxx' and data[-1]['path'] == 'yyy.img'
 assert [e['index'] for e in data] == list(range(len(data)))
 EOF
-rm -f t1.cfg t2.cfg out.json
+rm -f t1.cfg out.json
 
-# create new cfg and manipulate entries
-./rkcfgtool --create t3.cfg --add foo bar.img --add baz qux.bin --del 0 --set-path 0 final.img >/dev/null
+echo "Creating new cfg..."
+./rkcfgtool t3.cfg --create --add foo bar.img --add baz qux.bin --del 0 --set-path 0 final.img >/dev/null
 ./rkcfgtool t3.cfg --json > out.json
 python3 - out.json <<'EOF'
 import json,sys
@@ -38,4 +47,16 @@ assert data[0]['name'] == 'baz' and data[0]['path'] == 'final.img'
 EOF
 rm -f t3.cfg out.json
 
-echo "OK"
+echo "Creating cfg from scratch..."
+./rkcfgtool t4.cfg --create --add a a.img --add b b.img --add c c.img --set-name 1 bb >/dev/null
+./rkcfgtool t4.cfg --json > out.json
+python3 - out.json <<'EOF'
+import json,sys
+data=json.load(open(sys.argv[1]))
+assert len(data) == 3
+assert data[1]['name'] == 'bb'
+assert [e['index'] for e in data] == list(range(len(data)))
+EOF
+rm -f t4.cfg out.json
+
+echo "All tests passed"


### PR DESCRIPTION
## Summary
- support `--create` after <cfg> rather than before
- when `-o` is omitted, write changes back to input file
- document new behavior
- update tests for new invocation

## Testing
- `make lint`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68708a76557c832085924a8eac126b29