### PR TITLE
fix(cfg): preserve raw bytes and test binary output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,10 @@
 | Path            | Description                                                               |
 | --------------- | ------------------------------------------------------------------------- |
 | `rkcfgtool.cpp` | Main CLI tool (C++17) for reading/writing Rockchip binary CFG files.      |
+| `rkcfg.cpp`     | Parser and writer logic reused by `rkcfgtool`. |
+| `rkcfg.hpp`     | On-disk structures and helper functions. |
 | `test.sh`       | Shell script that builds `rkcfgtool` and executes basic regression tests. |
-| `cfg`           | RKDevTool configuration file and screenshot of the configuration                  |
+| `cfg`           | Sample Rockchip CFG files used in tests. |
 | `AGENTS.md`     | *← you are here* — workflow guide for AI agents.                          |
 
 ## Tool Overview & Principles
@@ -30,15 +32,15 @@
 Run **all** tests exactly like this:
 
 ```bash
+make lint
 ./test.sh
 
 # or
-make test
+make lint test
 ```
 
-The script must exit with status 0. If you need extra test cases, append them **inside** `test.sh` and keep the script idempotent.
-
-cfg files
+The script must exit with status 0. It rebuilds every cfg in `cfg/` and verifies the binaries match.
+Example operations:
 
 ```bash
 ./rkcfgtool cfg/config1.cfg --add add1 add1 -o config1_add1.cfg

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ cfg files
 
 ```bash
 ./rkcfgtool cfg/config1.cfg --add add1 add1 -o config1_add1.cfg
-./rkcfgtool cfg/config1.cfg --disable 9 -o config1_disable9.cfg
+./rkcfgtool cfg/config1.cfg --enable 9 0 -o config1_enable9_off.cfg
 ./rkcfgtool cfg/config1.cfg --set-name 9 modified -o config1_modfied9_name.cfg
 ./rkcfgtool cfg/config1.cfg --set-path 9 modified -o config1_modfied9_path.cfg
 ./rkcfgtool cfg/config1.cfg --del 9 -o config1_remove9.cfg

--- a/Makefile
+++ b/Makefile
@@ -9,15 +9,15 @@ BINDIR ?= $(PREFIX)/bin
 
 all: $(TARGET)
 
-$(TARGET): rkcfgtool.cpp version.hpp
-	$(CXX) $(CXXFLAGS) -o $@ rkcfgtool.cpp
+$(TARGET): rkcfgtool.cpp rkcfg.cpp version.hpp rkcfg.hpp
+	$(CXX) $(CXXFLAGS) -o $@ rkcfgtool.cpp rkcfg.cpp
 
 install: $(TARGET)
-	install -d $(DESTDIR)$(BINDIR)
-	install -m 0755 $(TARGET) $(DESTDIR)$(BINDIR)/$(TARGET)
+		install -d $(DESTDIR)$(BINDIR)
+		install -m 0755 $(TARGET) $(DESTDIR)$(BINDIR)/$(TARGET)
 
 lint:
-	$(CXX) $(CXXFLAGS) -fsyntax-only rkcfgtool.cpp
+	        $(CXX) $(CXXFLAGS) -fsyntax-only rkcfgtool.cpp rkcfg.cpp
 
 test: $(TARGET)
 	./test.sh

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # rkcfgtool
 
 Command line utility for Rockchip RKDevTool configuration files.
-It can list, edit and create CFG entries.
+It can list, edit and create CFG entries. Parts of this project were developed
+with reference to [PenUniverse/RKCfgTool](https://github.com/PenUniverse/RKCfgTool).
 
 ## Build
 
@@ -24,7 +25,7 @@ Actions:
 - `--set-name <idx> <newName>` – change name of entry
 - `--add <name> <path>` – append a new entry
 - `--del <idx>` – delete entry
-- `--disable <idx>` – clear path of entry
+ - `--enable <idx> <1|0>` – set enable flag for entry
 - `--json` – output entries as JSON
 - `--create` – start a new config instead of reading one
 - `--version` – show rkcfgtool version

--- a/rkcfg.cpp
+++ b/rkcfg.cpp
@@ -1,0 +1,66 @@
+#include "rkcfg.hpp"
+#include <algorithm>
+#include <codecvt>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <locale>
+
+static std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> cvt;
+
+
+bool readRkcfg(const std::string &path, RKCfgHeader &hdr,
+               std::vector<Entry> &items) {
+  std::ifstream in(path, std::ios::binary);
+  if (!in) {
+    std::cerr << "Cannot open " << path << "\n";
+    return false;
+  }
+  in.read(reinterpret_cast<char *>(&hdr), sizeof(hdr));
+  if (std::strncmp(hdr.magic, "CFG", 3) != 0) {
+    std::cerr << "Bad magic number\n";
+    return false;
+  }
+  if (hdr.itemSize != sizeof(RKCfgItem)) {
+    std::cerr << "Unsupported item size\n";
+    return false;
+  }
+  items.clear();
+  for (size_t i = 0; i < hdr.length; ++i) {
+    RKCfgItem item{};
+    in.read(reinterpret_cast<char *>(&item), sizeof(item));
+    if (item.size != hdr.itemSize) {
+      std::cerr << "Item size mismatch\n";
+      return false;
+    }
+    Entry e{};
+    e.raw = item;
+    e.name = readFixed(item.name, 40);
+    e.path = readFixed(item.imagePath, 260);
+    e.address = item.address;
+    e.selected = item.isSelected;
+    items.push_back(std::move(e));
+  }
+  return true;
+}
+
+bool writeRkcfg(const std::string &path, RKCfgHeader hdr,
+                const std::vector<Entry> &items) {
+  hdr.length = static_cast<uint8_t>(items.size());
+  std::ofstream out(path, std::ios::binary);
+  if (!out) {
+    std::cerr << "Cannot write " << path << "\n";
+    return false;
+  }
+  out.write(reinterpret_cast<const char *>(&hdr), sizeof(hdr));
+  for (const auto &e : items) {
+    RKCfgItem item = e.raw;
+    item.size = hdr.itemSize;
+    item.address = e.address;
+    item.isSelected = e.selected;
+    out.write(reinterpret_cast<const char *>(&item), sizeof(item));
+  }
+  std::cout << "Written " << path << " ("
+            << sizeof(hdr) + sizeof(RKCfgItem) * items.size() << " bytes)\n";
+  return true;
+}

--- a/rkcfg.hpp
+++ b/rkcfg.hpp
@@ -1,0 +1,51 @@
+#pragma once
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+#include <algorithm>
+
+#pragma pack(push, 1)
+struct RKCfgHeader {
+  char magic[4];
+  char gap0[18];
+  uint8_t length;
+  uint32_t begin;
+  uint16_t itemSize;
+};
+
+struct RKCfgItem {
+  uint16_t size;
+  char16_t name[40];
+  char16_t imagePath[260];
+  uint32_t address;
+  uint8_t isSelected;
+  char gap1[3];
+};
+#pragma pack(pop)
+
+inline std::u16string readFixed(const char16_t *buf, size_t len) {
+  size_t n = 0;
+  while (n < len && buf[n])
+    ++n;
+  return std::u16string(buf, n);
+}
+
+inline void writeFixed(char16_t *dest, size_t len, const std::u16string &s) {
+  std::fill_n(dest, len, 0);
+  size_t n = std::min(len - 1, s.size());
+  std::copy_n(s.data(), n, dest);
+}
+
+struct Entry {
+  RKCfgItem raw;
+  std::u16string name;
+  std::u16string path;
+  uint32_t address;
+  uint8_t selected;
+};
+
+bool readRkcfg(const std::string &path, RKCfgHeader &hdr,
+               std::vector<Entry> &items);
+bool writeRkcfg(const std::string &path, RKCfgHeader hdr,
+                const std::vector<Entry> &items);

--- a/rkcfgtool.cpp
+++ b/rkcfgtool.cpp
@@ -10,6 +10,7 @@
 #include <string>
 #include <vector>
 
+#include "rkcfg.hpp"
 #include "version.hpp"
 /*--------------------------------------------------------------------
  * 1. File layout (deduced from sample)
@@ -24,45 +25,12 @@
  *    └────────────┘  16×0 terminator
  *-------------------------------------------------------------------*/
 
-#pragma pack(push, 1)
-struct Header {
-  char magic[4];             // "CFG\0"
-  uint16_t day, year, month; // little-endian
-  uint16_t hour, minute, second;
-};
-#pragma pack(pop)
-
-struct Entry {
-  std::u16string name;
-  std::u16string path;
-  std::vector<uint8_t> gap;
-};
-
 // UTF-16LE ⇄ UTF-8 converter
 static std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> cvt;
 
 /*--------------------------------------------------------------------
  * 2. Helper functions
  *-------------------------------------------------------------------*/
-static std::u16string readU16Z(const std::vector<uint8_t> &buf, size_t &pos) {
-  size_t start = pos;
-  while (pos + 1 < buf.size()) { // search for 0x0000
-    if (buf[pos] == 0 && buf[pos + 1] == 0) {
-      pos += 2;
-      break;
-    }
-    pos += 2;
-  }
-  const char16_t *p = reinterpret_cast<const char16_t *>(&buf[start]);
-  return std::u16string(p, (pos - start) / 2 - 1); // drop terminator
-}
-
-static void writeU16Z(std::vector<uint8_t> &out, const std::u16string &s) {
-  const uint8_t *p = reinterpret_cast<const uint8_t *>(s.data());
-  out.insert(out.end(), p, p + s.size() * 2);
-  out.push_back(0);
-  out.push_back(0); // trailing 0x0000
-}
 
 static std::string jsonEscape(const std::string &s) {
   std::string out;
@@ -103,181 +71,23 @@ static std::string jsonEscape(const std::string &s) {
   return out;
 }
 
-// Find the next plausible UTF-16LE ASCII string beginning at or after `pos`.
-// Returns the starting offset or `std::string::npos` if none found.
-static size_t findAsciiU16(const std::vector<uint8_t> &buf, size_t pos) {
-  auto isAscii = [](uint8_t b) { return b >= 0x20 && b <= 0x7e; };
-  for (; pos + 3 < buf.size(); ++pos) {
-    if (buf[pos + 1] == 0 && isAscii(buf[pos]) && buf[pos + 3] == 0 &&
-        (isAscii(buf[pos + 2]) || buf[pos + 2] == 0)) {
-      return pos;
-    }
-  }
-  return std::string::npos;
-}
-
-static std::vector<uint8_t> createPrefix() {
-  Header hdr{};
+static RKCfgHeader createHeader() {
+  RKCfgHeader hdr{};
   std::memcpy(hdr.magic, "CFG", 3);
-  std::time_t t = std::time(nullptr);
-  std::tm tm = *std::localtime(&t);
-  hdr.day = tm.tm_mday;
-  hdr.year = tm.tm_year + 1900;
-  hdr.month = tm.tm_mon + 1;
-  hdr.hour = tm.tm_hour;
-  hdr.minute = tm.tm_min;
-  hdr.second = tm.tm_sec;
-
-  std::vector<uint8_t> buf(sizeof(Header) + 2, 0);
-  std::memcpy(buf.data(), &hdr, sizeof(hdr));
-  return buf;
+  hdr.begin = sizeof(RKCfgHeader);
+  hdr.itemSize = sizeof(RKCfgItem);
+  hdr.length = 0;
+  return hdr;
 }
 
-/*--------------------------------------------------------------------
- * 3. Parse existing CFG file
- *-------------------------------------------------------------------*/
-static bool parseCfg(const std::string &file, std::vector<uint8_t> &raw,
-                     std::vector<uint8_t> &prefix, std::vector<Entry> &items,
-                     std::vector<uint8_t> &suffix) {
-  std::ifstream in(file, std::ios::binary);
-  if (!in) {
-    std::cerr << "Cannot open " << file << '\n';
-    return false;
-  }
-
-  raw.assign(std::istreambuf_iterator<char>(in),
-             std::istreambuf_iterator<char>());
-
-  if (raw.size() < sizeof(Header)) {
-    std::cerr << "File too small\n";
-    return false;
-  }
-  auto *hdr = reinterpret_cast<const Header *>(raw.data());
-  if (std::string(hdr->magic, 3) != "CFG") {
-    std::cerr << "Bad magic number\n";
-    return false;
-  }
-
-  // Copy header and locate first UTF-16 entry heuristically
-  size_t pos = sizeof(Header);
-  while (pos < raw.size() && raw[pos] == 0)
-    ++pos; // skip zeros
-  if (pos & 1)
-    ++pos; // ensure 2‑byte alignment
-  pos = findAsciiU16(raw, pos);
-  if (pos == std::string::npos) {
-    std::cerr << "No entries found in " << file << '\n';
-    return false;
-  }
-  prefix.assign(raw.begin(), raw.begin() + pos);
-  size_t lastEnd = pos;
-
-  // Extract all UTF-16 strings along with their byte ranges and gaps
-  std::vector<std::u16string> strs;
-  std::vector<std::pair<size_t, size_t>> ranges;
-  std::vector<std::vector<uint8_t>> gaps;
-  auto validAscii = [](char16_t c) { return c >= 0x21 && c < 0x7f; };
-  while (pos != std::string::npos && pos + 1 < raw.size()) {
-    size_t start = pos;
-    std::u16string s = readU16Z(raw, pos);
-    size_t end = pos;
-    lastEnd = pos;
-    bool ok = !s.empty();
-    bool hasAlnum = false;
-    for (char16_t ch : s) {
-      if (!validAscii(ch)) {
-        ok = false;
-        break;
-      }
-      if (std::isalnum(static_cast<unsigned char>(ch)))
-        hasAlnum = true;
-    }
-    if (ok && hasAlnum) {
-      strs.push_back(std::move(s));
-      ranges.emplace_back(start, end);
-    }
-    size_t next = findAsciiU16(raw, pos);
-    if (ok && hasAlnum) {
-      gaps.emplace_back(raw.begin() + pos, next == std::string::npos
-                                               ? raw.end()
-                                               : raw.begin() + next);
-    }
-    pos = next;
-  }
-
-  if (!gaps.empty()) {
-    suffix = std::move(gaps.back());
-    gaps.pop_back();
-  } else {
-    suffix.clear();
-  }
-
-  // Pair them as name/path entries. Some files may omit paths for certain
-  // names. Heuristically treat a string as a path only if it looks like one.
-  // However, configs generated by rkcfgtool itself always store entries in
-  // strict name/path order. If heuristic detection yields no paths at all,
-  // fall back to pairing consecutively.
-  bool forcePair = false;
-  {
-    size_t pathCount = 0;
-    for (size_t i = 1; i < strs.size(); ++i) {
-      const auto &cand = strs[i];
-      if (cand.find(u'\\') != std::u16string::npos ||
-          cand.find(u'/') != std::u16string::npos ||
-          cand.find(u'.') != std::u16string::npos) {
-        ++pathCount;
-      }
-    }
-    if (pathCount == 0 && (strs.size() % 2 == 0))
-      forcePair = true;
-  }
-
-  for (size_t i = 0, g = 0; i < strs.size(); ++i, ++g) {
-    Entry e;
-    e.name = std::move(strs[i]);
-    if (i + 1 < strs.size()) {
-      const auto &cand = strs[i + 1];
-      bool looksLikePath = cand.find(u'\\') != std::u16string::npos ||
-                           cand.find(u'/') != std::u16string::npos ||
-                           cand.find(u'.') != std::u16string::npos;
-      if (forcePair || looksLikePath) {
-        e.path = cand;
-        ++i;
-        ++g;
-      }
-    }
-    if (g < gaps.size())
-      e.gap = std::move(gaps[g]);
-    items.push_back(std::move(e));
-  }
-
-  return true;
+static bool parseCfg(const std::string &file, RKCfgHeader &hdr,
+                     std::vector<Entry> &items) {
+  return readRkcfg(file, hdr, items);
 }
 
-/*--------------------------------------------------------------------
- * 4. Rebuild & write CFG
- *-------------------------------------------------------------------*/
-static bool rebuildAndWrite(const std::string &outFile,
-                            const std::vector<uint8_t> &prefix,
-                            const std::vector<Entry> &items,
-                            const std::vector<uint8_t> &suffix) {
-  std::vector<uint8_t> out(prefix); // header + zeros
-  for (const auto &e : items) {
-    writeU16Z(out, e.name);
-    writeU16Z(out, e.path);
-    out.insert(out.end(), e.gap.begin(), e.gap.end());
-  }
-  out.insert(out.end(), suffix.begin(), suffix.end());
-
-  std::ofstream ofs(outFile, std::ios::binary);
-  if (!ofs) {
-    std::cerr << "Cannot write " << outFile << '\n';
-    return false;
-  }
-
-  ofs.write(reinterpret_cast<const char *>(out.data()), out.size());
-  std::cout << "Written " << outFile << " (" << out.size() << " bytes)\n";
-  return true;
+static bool rebuildAndWrite(const std::string &outFile, RKCfgHeader hdr,
+                            const std::vector<Entry> &items) {
+  return writeRkcfg(outFile, hdr, items);
 }
 
 /*--------------------------------------------------------------------
@@ -295,7 +105,7 @@ Actions (may repeat; executed in order):
   --set-name <idx> <newName>     Change name of entry <idx>
   --add      <name> <path>       Append a new entry
   --del      <idx>               Delete entry <idx>
-  --disable  <idx>               Clear path of entry <idx>
+  --enable   <idx> <1|0>         Set enable flag of entry <idx>
   --json                         Output entries as JSON
   --create                       Start a new CFG instead of reading one
   -o, --output <file>            Write result to <file>
@@ -325,7 +135,7 @@ int main(int argc, char *argv[]) {
     return 0;
   }
 
-  std::vector<uint8_t> raw, prefix, suffix;
+  RKCfgHeader hdr{};
   std::vector<Entry> items;
   bool jsonOut = false;
   std::string outFile;
@@ -337,10 +147,9 @@ int main(int argc, char *argv[]) {
       create = true;
 
   if (create) {
-    prefix = createPrefix();
-    suffix.assign(16, 0);
+    hdr = createHeader();
   } else {
-    if (!parseCfg(inFile, raw, prefix, items, suffix))
+    if (!parseCfg(inFile, hdr, items))
       return 1;
   }
 
@@ -360,6 +169,7 @@ int main(int argc, char *argv[]) {
         return 1;
       }
       items[idx].path = std::move(newP);
+      writeFixed(items[idx].raw.imagePath, 260, items[idx].path);
       modified = true;
     } else if (arg == "--set-name" && i + 2 < argc) {
       size_t idx = std::stoul(argv[++i]);
@@ -369,11 +179,15 @@ int main(int argc, char *argv[]) {
         return 1;
       }
       items[idx].name = std::move(newN);
+      writeFixed(items[idx].raw.name, 40, items[idx].name);
       modified = true;
     } else if (arg == "--add" && i + 2 < argc) {
-      Entry e;
+      Entry e{};
+      e.raw.size = hdr.itemSize;
       e.name = cvt.from_bytes(argv[++i]);
       e.path = cvt.from_bytes(argv[++i]);
+      writeFixed(e.raw.name, 40, e.name);
+      writeFixed(e.raw.imagePath, 260, e.path);
       items.push_back(std::move(e));
       modified = true;
     } else if (arg == "--del" && i + 1 < argc) {
@@ -384,13 +198,15 @@ int main(int argc, char *argv[]) {
       }
       items.erase(items.begin() + idx);
       modified = true;
-    } else if (arg == "--disable" && i + 1 < argc) {
+    } else if (arg == "--enable" && i + 2 < argc) {
       size_t idx = std::stoul(argv[++i]);
+      int flag = std::stoi(argv[++i]);
       if (idx >= items.size()) {
         std::cerr << "Index out of range\n";
         return 1;
       }
-      items[idx].path.clear();
+      items[idx].selected = flag ? 1 : 0;
+      items[idx].raw.isSelected = items[idx].selected;
       modified = true;
     } else if (arg == "--json") {
       jsonOut = true;
@@ -427,7 +243,7 @@ int main(int argc, char *argv[]) {
 
   // Write back if needed
   if (!outFile.empty())
-    return rebuildAndWrite(outFile, prefix, items, suffix) ? 0 : 1;
+    return rebuildAndWrite(outFile, hdr, items) ? 0 : 1;
 
   return 0;
 }

--- a/test.sh
+++ b/test.sh
@@ -59,4 +59,21 @@ assert [e['index'] for e in data] == list(range(len(data)))
 EOF
 rm -f t4.cfg out.json
 
+echo "Comparing binary outputs..."
+cp cfg/config1.cfg td.cfg
+for i in $(seq 0 9); do
+    ./rkcfgtool td.cfg --enable $i 0 -o td.cfg >/dev/null
+done
+tail -c +23 td.cfg > td.tail
+tail -c +23 cfg/config1_disable_all.cfg > exp.tail
+cmp -s td.tail exp.tail
+rm -f td.tail exp.tail
+cp cfg/config1.cfg t9.cfg
+./rkcfgtool t9.cfg --enable 9 0 -o t9.cfg >/dev/null
+tail -c +23 t9.cfg > t9.tail
+tail -c +23 cfg/config1_disable9.cfg > exp2.tail
+cmp -s t9.tail exp2.tail
+rm -f t9.tail exp2.tail
+rm -f td.cfg t9.cfg
+
 echo "All tests passed"

--- a/test.sh
+++ b/test.sh
@@ -13,6 +13,13 @@ for f in cfg/*.cfg; do
     ./rkcfgtool "$f" --json | python3 -m json.tool > /dev/null
 done
 
+echo "Verifying lossless rewrite..."
+for f in cfg/config?.cfg; do
+    ./rkcfgtool "$f" -o tmp.cfg >/dev/null
+    cmp -s "$f" tmp.cfg
+    rm -f tmp.cfg
+done
+
 echo "Parsing non-JSON output..."
 ./rkcfgtool cfg/config1.cfg > list.txt
 grep -q "=== Entry list" list.txt


### PR DESCRIPTION
## Summary
- store raw RKCfgItem bytes when reading configs
- reuse raw bytes when writing so unused padding is preserved
- update CLI actions to keep raw structures in sync
- test binary output for disabling entries

## Testing
- `make lint`
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6871cf25fb388320a4ed741b4e1c9179