### PR TITLE
feat(tool): show enable state and allow -1 index

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Actions:
 - `--create` – start a new config instead of reading one
 - `--version` – show rkcfgtool version
 - `--help` – show usage information
+- `<idx>` may be `-1` to target the last entry
+
+Plain output lists `index name path enabled`. JSON objects include an
+`"enabled"` field.
 
 ## Tests
 


### PR DESCRIPTION
## Summary
- display whether each entry is enabled in plain and JSON output
- accept `-1` for commands requiring an index to target the last entry
- document the new behavior
- update regression tests

## Testing
- `make lint test`

------
https://chatgpt.com/codex/tasks/task_e_6871f5a5b69483208b8ae75f07f319a5